### PR TITLE
非認証時とWeb経由時のリクエストが区別されず、screenNameのバリデーションが正しくない問題を修正

### DIFF
--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -6,7 +6,7 @@ export default function(req: any): Promise<{ app: any, user: any }> {
 	'use strict';
 	return new Promise<{ app: any, user: any }>((resolve, reject) => {
 		if (req.headers['passkey'] === undefined || req.headers['passkey'] === null) {
-			resolve({ app: null, user: null });
+			resolve({ app: undefined, user: undefined });
 		} else if (req.headers['passkey'] !== config.apiPasskey) {
 			reject();
 		} else if (req.headers['user-id'] === null) {

--- a/src/endpoints/account/create.ts
+++ b/src/endpoints/account/create.ts
@@ -1,14 +1,16 @@
 import * as bcrypt from 'bcrypt';
 import {User} from '../../models';
-import {IUser} from '../../interfaces';
+import {IApplication, IUser} from '../../interfaces';
 import {isScreenName} from '../../spec';
 
-export default function(screenName: string, password: string): Promise<IUser> {
+export default function(app: IApplication, screenName: string, password: string): Promise<IUser> {
 	'use strict';
 
-	return (screenName === undefined || screenName === null || screenName === '') ?
+	return (app !== null) ?
+		<Promise<any>>Promise.reject('access-denied')
+	: (screenName === undefined || screenName === null || screenName === '') ?
 		<Promise<any>>Promise.reject('empty-screen-name')
-	: (!isScreenName(screenName)) ?
+	: (!isScreenName(screenName) || screenName.length < 3) ?
 		<Promise<any>>Promise.reject('invalid-screen-name')
 	: (password === undefined || password === null || password === '') ?
 		<Promise<any>>Promise.reject('empty-password')

--- a/src/rest-handlers/account/create.ts
+++ b/src/rest-handlers/account/create.ts
@@ -10,6 +10,7 @@ export default function(
 ): void {
 	'use strict';
 	createAccount(
+		app,
 		req.payload['screen-name'],
 		req.payload['password']
 	).then(created => {


### PR DESCRIPTION
_緊急性の高いPRです_

Appを経由しないでリクエストした場合の`app`は`undefined`、Appを経由しないで公式Webからリクエストした場合の`app`は`null`とすることで区別できるようにした
API内部でいう`app`は**サードパーティアプリ**のことなのでWebからのリクエストは`null`とするのが理に適っています
